### PR TITLE
feat: 상품 목록 조회 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,12 @@ dependencies {
     compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
+    // Querydsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 }
 
 tasks.named('bootBuildImage') {

--- a/src/main/java/com/example/mission05/domain/goods/controller/GoodsController.java
+++ b/src/main/java/com/example/mission05/domain/goods/controller/GoodsController.java
@@ -3,6 +3,7 @@ package com.example.mission05.domain.goods.controller;
 import com.example.mission05.domain.goods.dto.GoodsRequestDto.CreateGoodsRequestDto;
 import com.example.mission05.domain.goods.dto.GoodsResponseDto.CreateGoodsResponseDto;
 import com.example.mission05.domain.goods.dto.GoodsResponseDto.GetGoodsResponseDto;
+import com.example.mission05.domain.goods.dto.GoodsResponseDto.SearchGoodsDto;
 import com.example.mission05.domain.goods.service.GoodsService;
 import com.example.mission05.domain.member.entity.type.AuthorityType.Authority;
 import com.example.mission05.global.dto.ResponseDto;
@@ -36,5 +37,16 @@ public class GoodsController {
     public ResponseDto<GetGoodsResponseDto> getGoods(@PathVariable Long goodsId) {
         GetGoodsResponseDto responseDto = goodsService.getGoods(goodsId);
         return ResponseDto.success("선택한 상품 조회 기능", responseDto);
+    }
+
+    @GetMapping
+    public ResponseDto<SearchGoodsDto> searchGoods(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "name") String sortBy,
+            @RequestParam(defaultValue = "asc") String orderBy
+    ) {
+        SearchGoodsDto responseDto = goodsService.searchGoods(page, size, sortBy, orderBy);
+        return ResponseDto.success("상품 목록 조회 기능", responseDto);
     }
 }

--- a/src/main/java/com/example/mission05/domain/goods/dto/GoodsResponseDto.java
+++ b/src/main/java/com/example/mission05/domain/goods/dto/GoodsResponseDto.java
@@ -3,6 +3,7 @@ package com.example.mission05.domain.goods.dto;
 import com.example.mission05.domain.goods.entity.Goods;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class GoodsResponseDto {
 
@@ -45,6 +46,18 @@ public class GoodsResponseDto {
                     goods.getCreatedAt(),
                     goods.getModifiedAt()
             );
+        }
+    }
+
+    public record SearchGoodsDto(
+            List<GetGoodsResponseDto> goodsList,
+            Integer page,
+            Integer count
+    ) {
+        public SearchGoodsDto(List<GetGoodsResponseDto> goodsList, Integer page, Integer count) {
+            this.goodsList = goodsList;
+            this.page = page;
+            this.count = count;
         }
     }
 }

--- a/src/main/java/com/example/mission05/domain/goods/repository/GoodsSearchRepository.java
+++ b/src/main/java/com/example/mission05/domain/goods/repository/GoodsSearchRepository.java
@@ -1,0 +1,37 @@
+package com.example.mission05.domain.goods.repository;
+
+import com.example.mission05.domain.goods.entity.Goods;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.JPQLQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.example.mission05.domain.goods.entity.QGoods.goods;
+
+@RequiredArgsConstructor
+@Repository
+public class GoodsSearchRepository {
+
+    private final JPQLQueryFactory jpqlQueryFactory;
+
+    public List<Goods> searchGoods(int page, int size, String sortBy, String orderBy) {
+        return jpqlQueryFactory.selectFrom(goods)
+                .orderBy(getSortedOrder(sortBy, orderBy))
+                .offset((long) page * size)
+                .limit(size)
+                .fetch();
+    }
+
+    private OrderSpecifier<?> getSortedOrder(String sortBy, String orderBy) {
+        PathBuilder<Goods> entityPath = new PathBuilder<>(Goods.class, "goods");
+
+        if (orderBy.equalsIgnoreCase("asc")) {
+            return entityPath.getString(sortBy).asc();
+        } else {
+            return entityPath.getString(sortBy).desc();
+        }
+    }
+}

--- a/src/main/java/com/example/mission05/domain/goods/service/GoodsService.java
+++ b/src/main/java/com/example/mission05/domain/goods/service/GoodsService.java
@@ -3,8 +3,10 @@ package com.example.mission05.domain.goods.service;
 import com.example.mission05.domain.goods.dto.GoodsRequestDto.CreateGoodsRequestDto;
 import com.example.mission05.domain.goods.dto.GoodsResponseDto.CreateGoodsResponseDto;
 import com.example.mission05.domain.goods.dto.GoodsResponseDto.GetGoodsResponseDto;
+import com.example.mission05.domain.goods.dto.GoodsResponseDto.SearchGoodsDto;
 import com.example.mission05.domain.goods.entity.Goods;
 import com.example.mission05.domain.goods.repository.GoodsRepository;
+import com.example.mission05.domain.goods.repository.GoodsSearchRepository;
 import com.example.mission05.domain.member.repository.MemberRepository;
 import com.example.mission05.global.exception.CustomApiException;
 import com.example.mission05.global.exception.ErrorCode;
@@ -12,11 +14,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @RequiredArgsConstructor
 @Service
 public class GoodsService {
 
     private final GoodsRepository goodsRepository;
+    private final GoodsSearchRepository goodsSearchRepository;
     private final MemberRepository memberRepository;
 
     @Transactional
@@ -36,5 +41,14 @@ public class GoodsService {
         );
 
         return new GetGoodsResponseDto(goods);
+    }
+
+    @Transactional(readOnly = true)
+    public SearchGoodsDto searchGoods(int page, int size, String sortBy, String orderBy) {
+        List<GetGoodsResponseDto> responseDtoList = goodsSearchRepository.searchGoods(page, size, sortBy, orderBy).stream()
+                .map(GetGoodsResponseDto::new)
+                .toList();
+
+        return new SearchGoodsDto(responseDtoList, page + 1, responseDtoList.size());
     }
 }

--- a/src/main/java/com/example/mission05/global/config/QueryDslConfig.java
+++ b/src/main/java/com/example/mission05/global/config/QueryDslConfig.java
@@ -1,0 +1,21 @@
+package com.example.mission05.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@RequiredArgsConstructor
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/example/mission05/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/mission05/global/config/WebSecurityConfig.java
@@ -72,6 +72,7 @@ public class WebSecurityConfig {
                 .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
                 .requestMatchers("/api/v1/members/*").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/v1/goods/{goodsId}").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/v1/goods").permitAll()
                 .requestMatchers(PathRequest.toH2Console()).permitAll()
                 .anyRequest().authenticated()
         );


### PR DESCRIPTION
### 관련이슈

* #5 

### 변경사항

- 등록된 상품들을 조회할 수 있습니다.
    - 모든 사용자가 상품을 조회할 수 있습니다.
    - 페이지 별로 상품을 정해진 숫자만큼 순서대로 조회할 수 있습니다. (Paging)
- 조회된 상품 목록은 선택한 기준에 의해 정렬됩니다.
    - `상품명`, `가격` 중 기준을 선택할 수 있습니다.
    - 내림차순, 오름차순을 선택할 수 있습니다.

### 테스트

- [ ] 테스트 코드
- [x] API 테스트