### PR TITLE
feat: 장바구니 조회 기능

### DIFF
--- a/src/main/java/com/example/mission05/domain/basket/controller/BasketController.java
+++ b/src/main/java/com/example/mission05/domain/basket/controller/BasketController.java
@@ -1,5 +1,6 @@
 package com.example.mission05.domain.basket.controller;
 
+import com.example.mission05.domain.basket.dto.BasketResponseDto.GetBasketListResponseDto;
 import com.example.mission05.domain.basket.service.BasketService;
 import com.example.mission05.domain.goods.dto.GoodsRequestDto.BuyGoodsRequestDto;
 import com.example.mission05.domain.goods.dto.GoodsResponseDto.BuyGoodsResponseDto;
@@ -25,5 +26,13 @@ public class BasketController {
     ) {
         BuyGoodsResponseDto responseDto = basketService.buyGoods(userDetails.getUsername(), goodsId, requestDto);
         return ResponseDto.success("장바구니 추가 기능", responseDto);
+    }
+
+    @GetMapping
+    public ResponseDto<GetBasketListResponseDto> getBasketList(
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        GetBasketListResponseDto result = basketService.getBasketList(userDetails.getUsername());
+        return ResponseDto.success("장바구니 조회 기능", result);
     }
 }

--- a/src/main/java/com/example/mission05/domain/basket/dto/BasketResponseDto.java
+++ b/src/main/java/com/example/mission05/domain/basket/dto/BasketResponseDto.java
@@ -1,4 +1,25 @@
 package com.example.mission05.domain.basket.dto;
 
+import java.util.List;
+
 public class BasketResponseDto {
+
+    public record GetBasketResponseDto(
+            String name,
+            Integer price,
+            Integer amount
+    ) {
+        public GetBasketResponseDto(String name, Integer price, Integer amount) {
+            this.name = name;
+            this.price = price;
+            this.amount = amount;
+        }
+    }
+
+    public record GetBasketListResponseDto(
+            List<GetBasketResponseDto> goods,
+            Long totalPrice
+    ) {
+
+    }
 }

--- a/src/main/java/com/example/mission05/domain/basket/repository/BasketRepository.java
+++ b/src/main/java/com/example/mission05/domain/basket/repository/BasketRepository.java
@@ -5,9 +5,12 @@ import com.example.mission05.domain.goods.entity.Goods;
 import com.example.mission05.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface BasketRepository extends JpaRepository<Basket, Long> {
 
     Optional<Basket> findByMemberAndGoods(Member member, Goods goods);
+
+    List<Basket> findByMemberOrderByCreatedAtDesc(Member member);
 }


### PR DESCRIPTION
### 관련이슈

* #7 

### 변경사항

- 장바구니에 추가된 상품들의 정보와 수량을 조회할 수 있습니다.
    - 로그인을 통해 발급받은 JWT가 함께 요청됩니다.
    - 회원만 장바구니 조회가 가능합니다.
- 장바구니에 담긴 상품들의 총 결제 금액을 확인할 수 있습니다.

### 테스트

- [ ] 테스트 코드
- [x] API 테스트