### PR TITLE
feat: 장바구니 삭제 기능

### DIFF
--- a/src/main/java/com/example/mission05/domain/basket/controller/BasketController.java
+++ b/src/main/java/com/example/mission05/domain/basket/controller/BasketController.java
@@ -10,6 +10,7 @@ import com.example.mission05.global.dto.ResponseDto;
 import com.example.mission05.global.security.UserDetailsImpl;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -45,5 +46,15 @@ public class BasketController {
             @RequestBody @Valid EditBasketRequestDto requestDto) {
         GetBasketResponseDto responseDto = basketService.editBasket(userDetails.getUsername(), basketId, requestDto);
         return ResponseDto.success("장바구니 수정 기능", responseDto);
+    }
+
+    @DeleteMapping("/baskets/{basketId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public ResponseDto<Void> deleteBasket(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long basketId
+    ) {
+        basketService.deleteBasket(userDetails.getUsername(), basketId);
+        return ResponseDto.success("장바구니 삭제 기능", null);
     }
 }

--- a/src/main/java/com/example/mission05/domain/basket/service/BasketService.java
+++ b/src/main/java/com/example/mission05/domain/basket/service/BasketService.java
@@ -112,4 +112,19 @@ public class BasketService {
         }
         return new GetBasketResponseDto(goods.getName(), goods.getPrice(), basket.getAmount());
     }
+
+    @Transactional
+    public void deleteBasket(String email, Long basketId) {
+        Member member = memberRepository.findByEmail(email).orElseThrow(() ->
+                new CustomApiException(ErrorCode.NOT_FOUND_EMAIL.getMessage())
+        );
+        Basket basket = basketRepository.findById(basketId).orElseThrow(() ->
+                new CustomApiException(ErrorCode.NOT_FOUND_BASKET.getMessage())
+        );
+        if (basket.getMember() != member) {
+            throw new CustomApiException(ErrorCode.NOT_INCORRECT_MEMBER.getMessage());
+        }
+
+        basketRepository.delete(basket);
+    }
 }


### PR DESCRIPTION
### 관련이슈

* #9 

### 변경사항

- 장바구니에서 선택한 상품을 삭제할 수 있습니다.
    - 로그인을 통해 발급받은 JWT가 함께 요청됩니다.
    - 회원만 장바구니 삭제가 가능합니다.
- 장바구니 삭제 성공을 확인할 수 있는 값을 반환합니다.
    - ex) HTTP Status Code, Error Message …

### 테스트

- [ ] 테스트 코드
- [x] API 테스트